### PR TITLE
docs(readme): add auto-session integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A Neovim plugin to vacuum up unused file buffers
   - [📦 Installation](<#-installation>)
   - [⚙️ Configuration](<#%EF%B8%8F-configuration>)
   - [🚀 Usage](<#-usage>)
+  - [Session Persistence](<#session-persistence>)
   - [Plugins that work well with Buffer Vacuum](<#plugins-that-work-well-with-buffer-vacuum>)
 
 ## 📦 Installation
@@ -66,6 +67,39 @@ Buffer-Vacuum comes with the following defaults:
 - **BufferVacuumToggle**: Toggle buffer-vacuum
 - **BufferVacuumEnable**: Enable buffer-vacuum
 - **BufferVacuumDisable**: Disable buffer-vacuum
+
+## Session Persistence
+
+### Auto-session Integration
+
+If you're using [auto-session](https://github.com/rmagatti/auto-session) and want pinned buffers to persist across sessions, you need to add the following configuration to your auto-session setup:
+
+```lua
+require('auto-session').setup({
+    save_extra_cmds = {
+        function()
+            local commands = {}
+            for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+                if vim.b[bufnr].pinned == 1 then
+                    local filename = vim.api.nvim_buf_get_name(bufnr)
+                    if filename ~= "" then
+                        -- Generate command to set buffer variable directly
+                        local escaped_filename = vim.fn.escape(filename, "'\\")
+                        table.insert(commands, "call setbufvar(bufnr('" .. escaped_filename .. "'), 'pinned', 1)")
+                    end
+                end
+            end
+            if vim.tbl_isempty(commands) then
+                return nil
+            end
+            return commands
+        end
+    }
+    -- your other auto-session options...
+})
+```
+
+Without this configuration, pinned buffers will not be remembered when you restore a session.
 
 ## Plugins that work well with Buffer Vacuum
 


### PR DESCRIPTION
It is mentioned that auto-session works with this plugin however It was not the case for me. I have had to make some changes in my auto-session configuration to achieve session persistent.

So I think It is a good idea to document how to integrate the two plugins in the Readme.